### PR TITLE
Fix: 結果ボックスの高さを固定してちらつきを防止

### DIFF
--- a/style.css
+++ b/style.css
@@ -103,7 +103,7 @@ header p {
 }
 
 .result-display {
-    min-height: 120px;
+    height: 120px;
     background: #f8f9fa;
     border-radius: 15px;
     padding: 30px;
@@ -112,7 +112,12 @@ header p {
     justify-content: center;
     font-size: 3rem;
     border: 2px dashed #e0e0e0;
-    transition: all 0.3s ease;
+    transition: background 0.3s ease, border-color 0.3s ease;
+    overflow: auto;
+    box-sizing: border-box;
+    word-wrap: break-word;
+    text-align: center;
+    line-height: 1.2;
 }
 
 .result-display:not(:empty) {
@@ -123,6 +128,7 @@ header p {
 .result-display.loading {
     color: #667eea;
     font-size: 1.5rem;
+    line-height: 1.2;
 }
 
 /* フッター */
@@ -304,6 +310,7 @@ footer p {
     .result-display {
         font-size: 2.5rem;
         padding: 20px;
+        height: 100px;
     }
     
     .action-buttons {
@@ -341,6 +348,7 @@ footer p {
     
     .result-display {
         font-size: 2rem;
-        min-height: 100px;
+        height: 90px;
+        padding: 15px;
     }
 }


### PR DESCRIPTION
- result-display の min-height を height に変更
- 全画面サイズで一定の高さを維持
- overflow: auto でコンテンツが多い場合のスクロール対応
- transition を最適化してパフォーマンス向上
- word-wrap と line-height でテキスト表示を改善

🤖 Generated with [Claude Code](https://claude.ai/code)